### PR TITLE
Provide better support for Xcode 12 and SPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+/.swiftpm

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,11 +39,11 @@
       },
       {
         "package": "Xgen",
-        "repositoryURL": "https://github.com/JohnSundell/Xgen.git",
+        "repositoryURL": "https://github.com/moyerr/Xgen.git",
         "state": {
-          "branch": null,
-          "revision": "bc7ec3bf76e63c317d1523c865d65023f450eb0b",
-          "version": "2.0.1"
+          "branch": "xcode-12-build-active-scheme",
+          "revision": "ad0a231bc449390e20e9bae7e0dfe972f575f185",
+          "version": null
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,7 +41,7 @@
         "package": "Xgen",
         "repositoryURL": "https://github.com/moyerr/Xgen.git",
         "state": {
-          "branch": "xcode-12-build-active-scheme",
+          "branch": "main",
           "revision": "ad0a231bc449390e20e9bae7e0dfe972f575f185",
           "version": null
         }

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 let package = Package(
     name: "TestDrive",
     dependencies: [
-        .package(url: "https://github.com/JohnSundell/Xgen.git", from: "2.0.0"),
+        .package(url: "https://github.com/moyerr/Xgen.git", .branch("xcode-12-build-active-scheme")),
         .package(url: "https://github.com/JohnSundell/Files.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Releases.git", from: "2.0.0")

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 let package = Package(
     name: "TestDrive",
     dependencies: [
-        .package(url: "https://github.com/moyerr/Xgen.git", .branch("xcode-12-build-active-scheme")),
+        .package(url: "https://github.com/moyerr/Xgen.git", .branch("main")),
         .package(url: "https://github.com/JohnSundell/Files.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Releases.git", from: "2.0.0")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -155,7 +155,7 @@ struct Target {
 struct Package {
     let name: String
     let folder: Folder
-    let projectPath: String
+    let projectPath: String?
 }
 
 class PackageLoader {
@@ -248,10 +248,8 @@ class PackageLoader {
         }
 
         if repositoryFolder.containsFile(named: "Package.swift") {
-            let projectName = "\(name).xcodeproj"
-            try shellOut(to: "swift package generate-xcodeproj --output \(projectName)", at: repositoryFolder.path)
             print("🚗  \(name) is ready for test drive\n")
-            return Package(name: name, folder: repositoryFolder, projectPath: name + "/" + projectName)
+            return Package(name: name, folder: repositoryFolder, projectPath: nil)
         }
 
         throw TestDriveError.missingXcodeProject(url)
@@ -319,8 +317,14 @@ do {
 
     for package in packages {
         try package.folder.move(to: projectsFolder)
-        let projectPath = "\(workspaceName)/Projects/\(package.projectPath)"
-        workspace.addProject(at: projectPath)
+        
+        let projectsDirectory = "Projects/"
+        
+        if let projectPath = package.projectPath {
+            workspace.addProject(at: projectsDirectory + projectPath)
+        } else {
+            workspace.addReference(to: projectsDirectory + package.folder.name)
+        }
     }
 
     print("⚡️  Generating workspace at \(workspace.path)...")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -318,7 +318,7 @@ do {
     for package in packages {
         try package.folder.move(to: projectsFolder)
         
-        let projectsDirectory = "Projects/"
+        let projectsDirectory = "\(workspaceName)/Projects/"
         
         if let projectPath = package.projectPath {
             workspace.addProject(at: projectsDirectory + projectPath)

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -306,8 +306,8 @@ do {
     let packageNames = packages.map { $0.name }
 
     let workspaceName = "TestDrive-\(packageNames.joined(separator: "-")).xcworkspace"
-    let workspaceFolder = try FileSystem().createFolder(at: workspaceName)
-    let workspace = Workspace(path: workspaceFolder.path)
+    let workspaceFolder = try Folder.current.createSubfolder(named: workspaceName)
+    let workspace = Workspace(path: workspaceName)
 
     let playground = workspace.addPlayground()
     playground.platform = arguments.platform

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -238,6 +238,11 @@ class PackageLoader {
         try shellOut(to: "git checkout \(checkoutIdentifier) --quiet", at: repositoryFolder.path)
         try shellOut(to: "git submodule update --init --recursive --quiet", at: repositoryFolder.path)
 
+        if repositoryFolder.containsFile(named: "Package.swift") {
+            print("🚗  \(name) is ready for test drive\n")
+            return Package(name: name, folder: repositoryFolder, projectPath: nil)
+        }
+        
         for subfolder in repositoryFolder.makeSubfolderSequence(recursive: true) {
             if subfolder.isValidXcodeProject {
                 let projectPath = subfolder.path.replacingOccurrences(of: repositoryFolder.parent!.path, with: "")
@@ -245,11 +250,6 @@ class PackageLoader {
                 print("🚗  \(packageName) is ready for test drive\n")
                 return Package(name: packageName, folder: repositoryFolder, projectPath: projectPath)
             }
-        }
-
-        if repositoryFolder.containsFile(named: "Package.swift") {
-            print("🚗  \(name) is ready for test drive\n")
-            return Package(name: name, folder: repositoryFolder, projectPath: nil)
         }
 
         throw TestDriveError.missingXcodeProject(url)


### PR DESCRIPTION
- Import Swift Packages directly (no need for `.xcodeproj` anymore)
- Better portability of the generated `.xcworkspace` because the FileRefs are added with a relative path